### PR TITLE
Draw over all apps correctly

### DIFF
--- a/pomodoro.py
+++ b/pomodoro.py
@@ -193,7 +193,7 @@ def reward_alert() -> None:
        popup if reward
     """
     root = tk.Tk()
-    root.attributes('-topmost')
+    root.attributes('-topmost', 1)
     root.withdraw()
     messagebox.showwarning(
             'You got a Reward!',


### PR DESCRIPTION
Add correct parameters to Tkinter.attributes to allow correct drawing of alert window.
